### PR TITLE
register boolean type so schema can be dumped

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -58,6 +58,7 @@ module ActiveRecord
           super(m)
 
           register_class_with_limit m, %r(String), Type::String
+          register_class_with_limit m, 'Bool', Type::Boolean
           register_class_with_limit m, 'Date', Clickhouse::OID::Date
           register_class_with_limit m, 'DateTime', Clickhouse::OID::DateTime
 


### PR DESCRIPTION
for db fields like `t.boolean "fieldname", null: false` the schema could not be dumped, so i added it to the list

Besides i have another issue with date fields with defaults:

` t.date "starts_at", default: "1970-01-01", null: false`  gets dumped like:  `t.date "starts_at", default: Thu, 01 Jan 1970, null: false`
It should use the provided date-string instead of an inspected Date object. Is this what OID::Date#type_cast_for_schema is for?

Also in the dumped schema the main class was still ClickhouseActiverecord::Schema, which i needed to change to  ActiveRecord::Schema.define .. 
(Using Rails 7+ruby 3.2)
