### PR TITLE
Use old sorting behavior for clickhouse_structure.sql

### DIFF
--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -47,7 +47,9 @@ module ClickhouseActiverecord
         .reject { |name| /\.inner/.match?(name) || %w[schema_migrations ar_internal_metadata].include?(name) }
         .map { |name| connection.show_create_table(name, single_line: false).gsub("#{@configuration.database}.", '') }
       views, tables = table_defs.partition { |sql| sql.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) }
-      definitions = functions.sort + tables.sort + views.sort
+      mat_views, views = views.partition { |sql| sql.match(/^CREATE\s+MATERIALIZED\s+VIEW/) }
+
+      definitions = functions.sort + mat_views.sort + tables.sort + views.sort
 
       File.open(path, 'w:utf-8') do |file|
         definitions.each do |sql|

--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -36,29 +36,22 @@ module ClickhouseActiverecord
       create
     end
 
-    def structure_dump(*args)
+    def structure_dump(path, *)
       establish_master_connection
 
-      # get all tables
-      tables = connection.execute("SHOW TABLES FROM #{@configuration.database} WHERE name NOT LIKE '.inner_id.%'")['data'].flatten.map do |table|
-        next if %w[schema_migrations ar_internal_metadata].include?(table)
-        connection.show_create_table(table, single_line: false).gsub("#{@configuration.database}.", '')
-      end.compact
+      functions = connection.execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name")['data']
+        .flatten
+        .map { |function| function.gsub('\\n', "\n") }
+      table_defs = connection.execute("SHOW TABLES FROM #{@configuration.database}")['data']
+        .flatten
+        .reject { |name| /\.inner/.match?(name) || %w[schema_migrations ar_internal_metadata].include?(name) }
+        .map { |name| connection.show_create_table(name, single_line: false).gsub("#{@configuration.database}.", '') }
+      views, tables = table_defs.partition { |sql| sql.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) }
+      definitions = functions.sort + tables.sort + views.sort
 
-      # sort view to last
-      tables.sort_by! {|table| table.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) ? 1 : 0}
-
-      # get all functions
-      functions = connection.execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name")['data'].flatten
-
-      # put to file
-      File.open(args.first, 'w:utf-8') do |file|
-        functions.each do |function|
-          file.puts function.gsub('\\n', "\n") + ";\n\n"
-        end
-
-        tables.each do |table|
-          file.puts table + ";\n\n"
+      File.open(path, 'w:utf-8') do |file|
+        definitions.each do |sql|
+          file.puts "#{sql};\n\n"
         end
       end
     end


### PR DESCRIPTION
This would use the old sorting. TBH I need to know exactly what was broken about the structure file, because both of these seem like they would work to me.

They both define functions, then tables, then views. The only difference should be the order of the tables themselves.

By calling `table.sort`, we define all of the dictionaries first.