### PR TITLE
Updates for Rails 8

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/column.rb
+++ b/lib/active_record/connection_adapters/clickhouse/column.rb
@@ -2,10 +2,9 @@ module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
       class Column < ActiveRecord::ConnectionAdapters::Column
-
         attr_reader :codec
 
-        def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil, codec: nil, **args)
+        def initialize(*, codec: nil, **)
           super
           @codec = codec
         end

--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -43,7 +43,12 @@ module ActiveRecord
             sql.gsub!(/\s+(.*)/, " \\1 CODEC(#{options[:codec]})")
           end
           sql.gsub!(/(\sString)\(\d+\)/, '\1')
-          sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
+
+          if ::ActiveRecord::version >= Gem::Version.new('8.1')
+            sql << " DEFAULT #{quote_default_expression_for_column_definition(options[:default], options[:column])}" if options_include_default?(options)
+          else
+            sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
+          end
           sql
         end
 

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -227,12 +227,18 @@ module ActiveRecord
         end
 
         def new_column_from_field(table_name, field, _definitions)
-          sql_type = field[1]
+          column_name, sql_type, default_type, default_expression = field
           type_metadata = fetch_type_metadata(sql_type)
-          default_value = extract_value_from_default(field[3], field[2])
-          default_function = extract_default_function(field[3])
-          default_value = lookup_cast_type(sql_type).cast(default_value)
-          Clickhouse::Column.new(field[0], default_value, type_metadata, field[1].include?('Nullable'), default_function, codec: field[5].presence)
+          default_value = extract_value_from_default(default_expression, default_type)
+          default_function = extract_default_function(default_expression)
+          cast_type = lookup_cast_type(sql_type)
+          default_value = cast_type.cast(default_value)
+
+          args = [column_name]
+          args << cast_type if ::ActiveRecord::version >= Gem::Version.new('8.1')
+          args += [default_value, type_metadata, field[1].include?('Nullable'), default_function]
+
+          Clickhouse::Column.new(*args, codec: field[5].presence)
         end
 
         # Extracts the value from a PostgreSQL column default definition.

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -537,8 +537,13 @@ module ActiveRecord
 
       protected
 
-      def last_inserted_id(result)
-        result
+      def last_inserted_id(_result)
+        # Rails 7.1 persistence.rb:1258:
+        # _write_attribute(column, value)  # wrote true directly — ugly but no crash
+
+        # Rails 8.0 persistence.rb:933:
+        # _write_attribute(column, type_for_attribute(column).deserialize(value))  # now deserializes first
+        nil
       end
 
       def change_column_for_alter(table_name, column_name, type, **options)

--- a/lib/arel/visitors/clickhouse.rb
+++ b/lib/arel/visitors/clickhouse.rb
@@ -66,7 +66,7 @@ module Arel
         collector << "SETTINGS "
         o.expr.each_with_index do |(key, value), i|
           collector << ", " if i > 0
-          collector << key.to_s.gsub(/\W+/, "")
+          collector << sanitize_as_setting_name(key).to_s
           collector << " = "
           collector << sanitize_as_setting_value(value)
         end
@@ -112,7 +112,7 @@ module Arel
 
       def sanitize_as_setting_name(value)
         return value if Arel::Nodes::SqlLiteral === value
-        @connection.sanitize_as_setting_name(value)
+        value.to_s.gsub(/\W+/, "")
       end
 
       private

--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -86,7 +86,33 @@ module ClickhouseActiverecord
       ActiveRecord::Migration.verbose = verbose_was
     end
 
+    def check_current_protected_environment!(db_config, migration_class = ActiveRecord::Migration)
+      with_temporary_pool(db_config, migration_class) do |pool|
+        migration_context = pool.migration_context
+        current = migration_context.current_environment
+        stored  = migration_context.last_stored_environment
+
+        if migration_context.protected_environment?
+          raise ActiveRecord::ProtectedEnvironmentError.new(stored)
+        end
+
+        if stored && stored != current
+          raise ActiveRecord::EnvironmentMismatchError.new(current: current, stored: stored)
+        end
+      rescue ActiveRecord::NoDatabaseError
+      end
+    end
+
     private
+
+    def with_temporary_pool(db_config, migration_class, clobber: false)
+      original_db_config = migration_class.connection_db_config
+      pool = migration_class.connection_handler.establish_connection(db_config, clobber: clobber)
+
+      yield pool
+    ensure
+      migration_class.connection_handler.establish_connection(original_db_config, clobber: clobber)
+    end
 
     def establish_master_connection
       establish_connection @configuration

--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -176,7 +176,8 @@ module CoreExtensions
       end
 
       def build_arel(connection_or_aliases = nil, aliases = nil)
-        if ::ActiveRecord::version >= Gem::Version.new('7.2')
+        requirement = Gem::Requirement.new('>= 7.2', '< 8.1')
+        if requirement.satisfied_by?(::ActiveRecord::version)
           arel = super
         else
           arel = super(connection_or_aliases)

--- a/spec/cluster/migration_spec.rb
+++ b/spec/cluster/migration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Cluster Migration', :migrations do
+RSpec.describe 'Cluster Migration', :migrations, cluster: true do
   describe 'performs migrations' do
     let(:model) do
       Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
This version should work for rails 7 and rails 8. So we should merge this first.

Once we upgrade WOTW, we can come back and remove the `primary_key` shim here.